### PR TITLE
fixed empty output from sed for Connected Network

### DIFF
--- a/rofi-wifi-menu.sh
+++ b/rofi-wifi-menu.sh
@@ -18,7 +18,7 @@ iwctl station $DEVICE scan
 
 ## Get the networks that are available to the WiFi adapter and format them.
 ## Make sure the current network is always at the top of the list.
-CURR_SSID=$(iwctl station $DEVICE show | sed -n 's/^\s*Connected\snetwork\s*\(\S*\)\s*$/\1/p')
+CURR_SSID=$(iwctl station $DEVICE show | sed -n 's/^.*Connected network\s*//p')
 IW_NETWORKS+=$(iwctl station $DEVICE get-networks | sed '/^--/d')
 IW_NETWORKS=$(echo "$IW_NETWORKS" | sed 1,4d)
 IW_NETWORKS=$(echo "$IW_NETWORKS" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")


### PR DESCRIPTION
The empty CURR_SSID is fixed with a corrected sed prompt